### PR TITLE
fix: Remove `GeometryTypeEnum` from step0

### DIFF
--- a/src/Hello0.ts
+++ b/src/Hello0.ts
@@ -4,10 +4,9 @@ import { VisibleComponent } from '@etherealengine/spatial/src/renderer/component
 import { TransformComponent } from '@etherealengine/spatial/src/transform/components/TransformComponent'
 import { PrimitiveGeometryComponent } from '@etherealengine/engine/src/scene/components/PrimitiveGeometryComponent'
 import { Vector3 } from 'three'
-import { GeometryTypeEnum } from '@etherealengine/engine/src/scene/constants/GeometryTypeEnum'
 
 const entity = ECS.createEntity()
 ECS.setComponent(entity, NameComponent, 'hello-world')
 ECS.setComponent(entity, VisibleComponent)
 ECS.setComponent(entity, TransformComponent, { position: new Vector3(0, 1, 0) })
-ECS.setComponent(entity, PrimitiveGeometryComponent, { geometryType: GeometryTypeEnum.SphereGeometry })
+ECS.setComponent(entity, PrimitiveGeometryComponent, { geometryType: 1 })


### PR DESCRIPTION
Adding GeometryTypeEnum is the very first step of the tutorial
This removes it, as the reader wouldn't have to do anything otherwise